### PR TITLE
fix make obs-workdir target

### DIFF
--- a/.ci/gh_release_to_obs_changeset.py
+++ b/.ci/gh_release_to_obs_changeset.py
@@ -28,6 +28,9 @@ url = f'https://api.github.com/repos/{args.repo}/releases{releaseSegment}'
 try:
     response = request.urlopen(url)
 except urllib.error.HTTPError as error:
+    if error.code == 404:
+        print(f"Release {args.tag} not found in {args.repo}. Skipping changelog generation.")
+        sys.exit(0)
     print(f"GitHub API responded with a {error.code} error!", file=sys.stderr)
     print("Url:", url, file=sys.stderr)
     print("Response:", json.dumps(json.load(error), indent=4), file=sys.stderr, sep="\n")

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ build/obs:
 	osc checkout $(OBS_PROJECT)/$(OBS_PACKAGE) -o build/obs
 	rm -f build/obs/*.tar.gz
 	cp -rv packaging/obs/* build/obs/
+	# we interpolate environment variables in OBS _service file so that we control what is downloaded by the tar_scm source service
 	sed -i 's~%%VERSION%%~$(VERSION)~' build/obs/_service
 	sed -i 's~%%REPOSITORY%%~$(REPOSITORY)~' build/obs/_service
 	cd build/obs; osc service runall

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # this is the what ends up in the RPM "Version" field and it is also used as suffix for the built binaries
-# if you want to commit to OBS it must correspond to a Git tag with an associated GitHub release
-# some targets like "obs-workdir" need a remotely available Git ref
+# if you want to commit to OBS it must be a remotely available Git reference
 VERSION ?= $(shell git rev-parse --short HEAD)
 
 # we only use this to comply with RPM changelog conventions at SUSE

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # this is the what ends up in the RPM "Version" field and it is also used as suffix for the built binaries
-# it can be arbitrary for local builds, but it if you want to commit to OBS it must correspond to a Git tag with an associated GitHub release
-VERSION ?= dev
+# if you want to commit to OBS it must correspond to a Git tag with an associated GitHub release
+# some targets like "obs-workdir" need a remotely available Git ref
+VERSION ?= $(shell git rev-parse --short HEAD)
 
 # we only use this to comply with RPM changelog conventions at SUSE
 AUTHOR ?= shap-staff@suse.de

--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,13 @@ build/obs:
 	osc checkout $(OBS_PROJECT)/$(OBS_PACKAGE) -o build/obs
 	rm -f build/obs/*.tar.gz
 	cp -rv packaging/obs/* build/obs/
-	sed -i 's/%%VERSION%%/$(VERSION)/' build/obs/_service
+	sed -i 's~%%VERSION%%~$(VERSION)~' build/obs/_service
+	sed -i 's~%%REPOSITORY%%~$(REPOSITORY)~' build/obs/_service
 	cd build/obs; osc service runall
 	.ci/gh_release_to_obs_changeset.py $(REPOSITORY) -a $(AUTHOR) -t $(VERSION) -f build/obs/$(OBS_PACKAGE).changes || true
 
 obs-commit: obs-workdir
 	cd build/obs; osc addremove
-	cd build/obs; osc commit -m "Automated $(VERSION) release"
+	cd build/obs; osc commit -m "Update to git ref $(VERSION)"
 
 .PHONY: default download install static-checks vet-check fmt fmt-check mod-tidy generate test clean clean-bin clean-obs build build-all obs-commit obs-workdir $(ARCHS)

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,24 +1,70 @@
 # Developer notes
 
+1. [Makefile](#makefile)
+2. [Generated Code](#generated-code)
+3. [OBS packaging](#obs-packaging)
+4. [SAP learning material](#sap-learning-material)
+
+
+## Makefile
+
+Most development tasks can be accomplished via [make](Makefile).
+
+For starters, you can run the default target with just `make`.
+
+The default target will clean, analyse, test and build the amd64 binary into the `build/bin` directory.
+
+You can also cross-compile to the various architectures we support with `make build-all`.
+
+
 ## Generated code
 
 Some of the code used in this repository is automatically generated.
+
+You can use the `make generate` target (which in turn runs `go generate`) to update generated code by taking advantage of the `//go:generate` annotation in the code.
+
+### Mocks
+
+We generate the mocks with the [GoMock](https://github.com/golang/mock) library. 
+
+All the mocked packages should follow the same convention and be put in the corresponding `mock_*` package inside the `test` directory.
+
+Only public interfaces should need to be mocked.
 
 ### SAPControl web service
 
 The for the [SAPControl web service](internal/sapcontrol/soap_wsdl.go), we generated the basic structure with [hooklift/gowsdl](https://github.com/hooklift/gowsdl), then extracted and adapted only the parts of the web service that we actually need.
 
-For reference, you can find the full, generated, web service code [here](_generated_soap_wsdl.go), but bear in mind that we don't intend to use its generated code as it is.
+For reference, you can find the full, generated, web service code [here](_generated_soap_wsdl.go), but bear in mind that we don't intend to use its generated code as it is. As such, note that this file is not covered by the `make generate` target.
 
-### Mocks
 
-We generate the mocks with the [GoMock](https://github.com/golang/mock) library.
+## OBS Packaging
 
-You can use the `make generate` target (which in turn runs `go generate`) to update generated code by taking advantage of the `//go:generate` annotation in the code. 
+The CI will automatically publish GitHub releases to SUSE's Open Build Service: to perform a new release, just publish a new GH release or push a git tag. Tags must always follow the [SemVer](https://semver.org/) scheme.
 
-All the mocked packages should follow the same convention and be put in the corresponding `mock_*` package inside the `test` directory.
+If you wish to produce an OBS working directory locally, having configured [`osc`](https://en.opensuse.org/openSUSE:OSC) already, you can run:
+```
+make obs-workdir
+```
+This will checkout the OBS project and prepare a new OBS commit in the `build/obs` directory.
 
-Only public interfaces should need to be mocked.
+Note that, by default, the current Git working directory HEAD reference is used to download the sources from the remote, so this reference must have been pushed beforehand.
+  
+You can use the `OSB_PROJECT`, `OBS_PACKAGE`, `REPOSITORY` and `VERSION` environment variables to change the behaviour of OBS-related make targets.
+
+For example, if you were on a feature branch of your own fork, you may want to change these variables, so:
+```bash
+git push feature/yxz # don't forget to make changes remotely available
+export OBS_PROJECT=home:JohnDoe
+export OBS_PACKAGE=my_project_branch
+export REPOSITORY=johndoe/my_forked_repo
+export VERSION=feature/yxz
+make obs-workdir
+``` 
+will prepare to commit on OBS into `home:JohnDoe/my_project_branch` by checking out the branch `feature/yxz` from `github.com/johndoe/my_forked_repo`.
+
+At last, to actually perform the commit into OBS, run `make obs-commit`. 
+
 
 ## SAP learning material
 
@@ -26,7 +72,7 @@ This section will provide some initial pointers to understand the documentation 
 
 Since we don't control the sources, some small changes may be introduced in the future, and the links might stop working; please feel free to submit a PR in case the documentation becomes outdated.
 
-###  Exploring the SAPControl web service
+### Exploring the SAPControl web service
 
 You can find the full documentation here: https://www.sap.com/documents/2016/09/0a40e60d-8b7c-0010-82c7-eda71af511fa.html
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SUSE/sap_host_exporter
 
-go 1.12
+go 1.11
 
 require (
 	github.com/golang/mock v1.4.1

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -1,14 +1,13 @@
 <services>
     <service name="tar_scm" mode="disabled">
-        <param name="url">git://github.com/SUSE/sap_host_exporter.git</param>
+        <param name="url">git://github.com/%%REPOSITORY%%.git</param>
         <param name="scm">git</param>
         <param name="revision">%%VERSION%%</param>
         <param name="exclude">.git</param>
-        <param name="versionformat">%h</param>
+        <param name="versionformat">@PARENT_TAG@+git.%ct.%h</param>
         <param name="filename">prometheus-sap_host_exporter</param>
     </service>
     <service name="set_version" mode="disabled">
-        <param name="version">%%VERSION%%</param>
         <param name="file">prometheus-sap_host_exporter.spec</param>
     </service>
     <service name="recompress" mode="disabled">

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -4,7 +4,7 @@
         <param name="scm">git</param>
         <param name="revision">%%VERSION%%</param>
         <param name="exclude">.git</param>
-        <param name="versionformat">@PARENT_TAG@</param>
+        <param name="versionformat">%h</param>
         <param name="filename">prometheus-sap_host_exporter</param>
     </service>
     <service name="set_version" mode="disabled">


### PR DESCRIPTION
This PR makes a few changes on how the `make obs-workdir` target works.

It now uses the `HEAD` reference as a default `VERSION` environment variable, and it now allows to also change the `REPOSITORY` variable to make the OBS `tar_scm` source service fetch the sources from a different repository than the main upstream.

Making OBS commits for Git feature branches on OBS branch packages is now documented in the development notes.

fixes #17