### PR TITLE
new OBS release process

### DIFF
--- a/.ci/gh_release_to_obs_changeset.py
+++ b/.ci/gh_release_to_obs_changeset.py
@@ -2,9 +2,10 @@
 
 import argparse
 import json
+import os
 import sys
 import textwrap
-from urllib import request
+import urllib.request
 import urllib.error
 from datetime import datetime
 from datetime import timezone
@@ -25,8 +26,14 @@ args = parser.parse_args()
 releaseSegment = f"/tags/{args.tag}" if args.tag else "/latest"
 url = f'https://api.github.com/repos/{args.repo}/releases{releaseSegment}'
 
+request = urllib.request.Request(url)
+
+githubToken = os.getenv("GITHUB_OAUTH_TOKEN")
+if githubToken:
+    request.add_header("Authorization", "token " + githubToken)
+
 try:
-    response = request.urlopen(url)
+    response = urllib.request.urlopen(request)
 except urllib.error.HTTPError as error:
     if error.code == 404:
         print(f"Release {args.tag} not found in {args.repo}. Skipping changelog generation.")

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@
 # Test binary, build with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
 # ignore binary
 sap_host_exporter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ cache:
   directories:
     - $GOPATH/pkg/mod
 
-stages:
-  - Test
-  - Release
-  - OBS Commit
-  - OBS Submit Request
-
 jobs:
   include:
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
         file_glob: true
         file: build/bin/*
         name: $TRAVIS_TAG
-        # ignore Travis alias warning, using "cleanup" doesn't work
         skip_cleanup: true
         overwrite: true
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script:
         - |
           docker run --rm -t -v "$(pwd):/package" -w /package \
-          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG -e GITHUB_OAUTH_TOKEN \
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"
     - stage: Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ cache:
 
 stages:
   - Test
-  - OBS commit
   - Release
+  - OBS Commit
+  - OBS Submit Request
 
 jobs:
   include:
@@ -19,19 +20,6 @@ jobs:
     - stage: Test
       name: Unit tests
       script: make test
-    - stage: OBS commit
-      if: branch = master OR tag IS present
-      name: Commit to OBS dev project
-      services:
-        - docker
-      env:
-        - VERSION=$TRAVIS_BRANCH
-      script:
-        - |
-          docker run --rm -t -v "$(pwd):/package" -w /package \
-          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG -e GITHUB_OAUTH_TOKEN \
-          shap/continuous_deliver \
-          bash -c "/scripts/init_osc_creds.sh && make obs-commit"
     - stage: Release
       name: Build and upload binaries on GitHub
       if: tag IS present
@@ -47,12 +35,26 @@ jobs:
         file_glob: true
         file: build/bin/*
         name: $TRAVIS_TAG
-        cleanup: false
+        # ignore Travis alias warning, using "cleanup" doesn't work
+        skip_cleanup: true
         overwrite: true
         on:
           tags: true
-    - stage: Release
-      name: Perform OBS Submit Request
+    - stage: OBS commit
+      name: Commit to OBS dev project
+      if: branch = master OR tag IS present
+      services:
+        - docker
+      env:
+        - VERSION=$TRAVIS_BRANCH
+      script:
+        - |
+          docker run --rm -t -v "$(pwd):/package" -w /package \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG -e GITHUB_OAUTH_TOKEN \
+          shap/continuous_deliver \
+          bash -c "/scripts/init_osc_creds.sh && make obs-commit"
+    - stage: OBS Submit Request
+      name: Submit Request to OBS stable project
       if: tag IS present
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,21 @@ jobs:
     - stage: Test
       name: Unit tests
       script: make test
-    - stage: Build & release
+    - stage: OBS release
+      if: type != pull_request AND branch = master
+      name: OBS Commit to dev project
+      services:
+        - docker
+      env:
+        - VERSION=$TRAVIS_COMMIT
+      script:
+        - |
+          docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
+          shap/continuous_deliver \
+          bash -c "/scripts/init_osc_creds.sh && make obs-commit" || travis_terminate 1
+    - stage: OBS release
+      name: OBS Submit Request to stable project
       if: tag IS present
       services:
         - docker
@@ -25,7 +39,7 @@ jobs:
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
-        file_glob: yes
+        file_glob: true
         file: build/bin/*
         name: $TRAVIS_TAG
         skip_cleanup: true
@@ -33,7 +47,7 @@ jobs:
           tags: true
       after_deploy:
         - |
-          docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
-          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
+          docker run --rm -t -v "$(pwd):/package" -w /package \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e PACKAGE_NAME=$OBS_PACKAGE -e TARGET_PROJECT=$OBS_DOWNSTREAM_PROJECT \
           shap/continuous_deliver \
-          bash -c "/scripts/init_osc_creds.sh && make obs-commit" || travis_terminate 1
+          bash -c "/scripts/submit.sh" || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       services:
         - docker
       env:
-        - VERSION=$TRAVIS_COMMIT
+        - VERSION=$TRAVIS_BRANCH
       script:
         - |
           docker run --rm -t -v "$(pwd):/package" -w /package \

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
         - VERSION=$TRAVIS_COMMIT
       script:
         - |
-          docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
+          docker run --rm -t -v "$(pwd):/package" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
     - stage: Test
       name: Unit tests
       script: make test
-    - stage: Release
+    - stage: Delivery
       if: type != pull_request AND branch = master
       name: OBS Commit to dev project
       services:
@@ -27,7 +27,7 @@ jobs:
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"
-    - stage: Release
+    - stage: Delivery
       name: Build and deploy binaries on GitHub release
       if: tag IS present
       services:
@@ -46,7 +46,7 @@ jobs:
         overwrite: true
         on:
           tags: true
-    - stage: Release
+    - stage: Delivery
       name: OBS Submit Request to stable project
       if: tag IS present
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
           tags: true
     - stage: OBS delivery
       name: Commit to OBS dev project
-      if: branch = master
+      if: branch = master AND type != pull_request
       services:
         - docker
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       script: make test
     - stage: OBS commit
       if: branch = master OR tag IS present
-      name: Commit to dev project
+      name: Commit to OBS dev project
       services:
         - docker
       env:
@@ -33,7 +33,7 @@ jobs:
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"
     - stage: Release
-      name: Build and deploy binaries
+      name: Build and upload binaries on GitHub
       if: tag IS present
       services:
         - docker
@@ -52,7 +52,7 @@ jobs:
         on:
           tags: true
     - stage: Release
-      name: Submit request to stable project
+      name: Perform OBS Submit Request
       if: tag IS present
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ cache:
   directories:
     - $GOPATH/pkg/mod
 
+stages:
+  - Test
+  - OBS commit
+  - Release
+
 jobs:
   include:
     - stage: Test
@@ -14,9 +19,9 @@ jobs:
     - stage: Test
       name: Unit tests
       script: make test
-    - stage: Delivery
-      if: type != pull_request AND branch = master
-      name: OBS Commit to dev project
+    - stage: OBS commit
+      if: branch = master OR tag IS present
+      name: Commit to dev project
       services:
         - docker
       env:
@@ -27,8 +32,8 @@ jobs:
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"
-    - stage: Delivery
-      name: Build and deploy binaries on GitHub release
+    - stage: Release
+      name: Build and deploy binaries
       if: tag IS present
       services:
         - docker
@@ -46,8 +51,8 @@ jobs:
         overwrite: true
         on:
           tags: true
-    - stage: Delivery
-      name: OBS Submit Request to stable project
+    - stage: Release
+      name: Submit request to stable project
       if: tag IS present
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
     - stage: Test
       name: Unit tests
       script: make test
-    - stage: OBS release
+    - stage: Release
       if: type != pull_request AND branch = master
       name: OBS Commit to dev project
       services:
@@ -26,9 +26,9 @@ jobs:
           docker run --rm -t -v "$(pwd):/package" -v "$GOPATH/pkg/mod:/root/go/pkg/mod" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG \
           shap/continuous_deliver \
-          bash -c "/scripts/init_osc_creds.sh && make obs-commit" || travis_terminate 1
-    - stage: OBS release
-      name: OBS Submit Request to stable project
+          bash -c "/scripts/init_osc_creds.sh && make obs-commit"
+    - stage: Release
+      name: Build and deploy binaries on GitHub release
       if: tag IS present
       services:
         - docker
@@ -38,16 +38,24 @@ jobs:
         - make -j4 build-all
       deploy:
         provider: releases
-        api_key: $GITHUB_OAUTH_TOKEN
+        token: $GITHUB_OAUTH_TOKEN
         file_glob: true
         file: build/bin/*
         name: $TRAVIS_TAG
-        skip_cleanup: true
+        cleanup: false
+        overwrite: true
         on:
           tags: true
-      after_deploy:
+    - stage: Release
+      name: OBS Submit Request to stable project
+      if: tag IS present
+      services:
+        - docker
+      env:
+        - VERSION=$TRAVIS_TAG
+      script:
         - |
           docker run --rm -t -v "$(pwd):/package" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e PACKAGE_NAME=$OBS_PACKAGE -e TARGET_PROJECT=$OBS_DOWNSTREAM_PROJECT \
           shap/continuous_deliver \
-          bash -c "/scripts/submit.sh" || travis_terminate 1
+          bash -c "/scripts/submit.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,20 +40,20 @@ jobs:
         overwrite: true
         on:
           tags: true
-    - stage: OBS commit
+    - stage: OBS delivery
       name: Commit to OBS dev project
-      if: branch = master OR tag IS present
+      if: branch = master
       services:
         - docker
       env:
-        - VERSION=$TRAVIS_BRANCH
+        - VERSION=$TRAVIS_COMMIT
       script:
         - |
           docker run --rm -t -v "$(pwd):/package" -w /package \
           -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG -e GITHUB_OAUTH_TOKEN \
           shap/continuous_deliver \
           bash -c "/scripts/init_osc_creds.sh && make obs-commit"
-    - stage: OBS Submit Request
+    - stage: OBS delivery
       name: Submit Request to OBS stable project
       if: tag IS present
       services:
@@ -63,6 +63,7 @@ jobs:
       script:
         - |
           docker run --rm -t -v "$(pwd):/package" -w /package \
-          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e PACKAGE_NAME=$OBS_PACKAGE -e TARGET_PROJECT=$OBS_DOWNSTREAM_PROJECT \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e OBS_PACKAGE -e VERSION -e REPOSITORY=$TRAVIS_REPO_SLUG -e GITHUB_OAUTH_TOKEN \
+          -e PACKAGE_NAME=$OBS_PACKAGE -e TARGET_PROJECT=$OBS_DOWNSTREAM_PROJECT \
           shap/continuous_deliver \
-          bash -c "/scripts/submit.sh"
+          bash -c "/scripts/init_osc_creds.sh && make obs-commit && /scripts/submit.sh"

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,13 @@ generate:
 test: download
 	go test -v ./...
 
-coverage: coverage.out
-coverage.out:
-	go test -cover -coverprofile=coverage.out ./...
-	go tool cover -html=coverage.out
+coverage:
+	go test -cover -coverprofile=build/coverage ./...
+	go tool cover -html=build/coverage
 
 clean: clean-bin clean-obs
 	go clean
-	rm -f coverage.out
+	rm -rf build
 
 clean-bin:
 	rm -rf build/bin
@@ -65,12 +64,12 @@ clean-bin:
 clean-obs:
 	rm -rf build/obs
 
-obs-workdir: build/obs
-build/obs:
-	osc checkout $(OBS_PROJECT)/$(OBS_PACKAGE) -o build/obs
+obs-workdir: clean-obs
+	mkdir -p build/obs
+	osc checkout $(OBS_PROJECT) $(OBS_PACKAGE) -o build/obs
 	rm -f build/obs/*.tar.gz
 	cp -rv packaging/obs/* build/obs/
-	# we interpolate environment variables in OBS _service file so that we control what is downloaded by the tar_scm source service
+# we interpolate environment variables in OBS _service file so that we control what is downloaded by the tar_scm source service
 	sed -i 's~%%VERSION%%~$(VERSION)~' build/obs/_service
 	sed -i 's~%%REPOSITORY%%~$(REPOSITORY)~' build/obs/_service
 	cd build/obs; osc service runall
@@ -80,4 +79,4 @@ obs-commit: obs-workdir
 	cd build/obs; osc addremove
 	cd build/obs; osc commit -m "Update to git ref $(VERSION)"
 
-.PHONY: default download install static-checks vet-check fmt fmt-check mod-tidy generate test clean clean-bin clean-obs build build-all obs-commit obs-workdir $(ARCHS)
+.PHONY: default download install static-checks vet-check fmt fmt-check mod-tidy generate test coverage clean clean-bin clean-obs build build-all obs-commit obs-workdir $(ARCHS)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test: download
 	go test -v ./...
 
 coverage:
+	@mkdir build
 	go test -cover -coverprofile=build/coverage ./...
 	go tool cover -html=build/coverage
 
@@ -65,7 +66,7 @@ clean-obs:
 	rm -rf build/obs
 
 obs-workdir: clean-obs
-	mkdir -p build/obs
+	@mkdir -p build/obs
 	osc checkout $(OBS_PROJECT) $(OBS_PACKAGE) -o build/obs
 	rm -f build/obs/*.tar.gz
 	cp -rv packaging/obs/* build/obs/


### PR DESCRIPTION
This PR updates the CI to change the release process to SUSE's downstream Open Build Service projects:

- Every time the master branch is updated (e.g. a PR gets merged into it), the `server:monitoring` project is updated. This is done via the existing `make obs-commit` automation. That is: the OBS development package (currently `server:monitoring/prometheus-sap_host_exporter`) is now synced with the master branch, instead of Git tags/releases. Said OBS package now effectively constitutes the development release to be used in conjunction with the `network:ha-clustering:Unstable` packages. 
- On Git tags, an OBS Submit Request is performed against the project specified in the `OBS_DOWNSTREAM_PROJECT` environment variable (currently set to `openSUSE:Factory` in the Travis settings), similarly to what [SUSE/hanadb_exporter](//github.com/SUSE/hanadb_exporter) does.
- The deployment of GitHub release assets is now performed in a dedicated job, in the `Release` stage, before the OBS operations.
- Also made some minor changes to the Makefile.

All of this has been tested in [my own fork](https://travis-ci.org/github/stefanotorresi/sap_host_exporter/builds).