### PR TITLE
add support for UDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,6 @@ The program will scan, in order, the current working directory, `$HOME/.config`,
 The first match has precedence, and the CLI flags have precedence over the config file.
 
 Please refer to the [example YAML configuration](doc/sap_host_exporter.yaml) for more details.
- 
-The SAPControl web service requires HTTP Basic authentication for most of its methods, hence it is strongly advised to configure these credentials in the configuration file; note that, by design, these values cannot be set via CLI flag.
-
-For the time being, these credentials are stored in plain-text, so be sure to properly take care of the file permissions (e.g. `chmod 600` it). 
-
-As a reminder, HTTP Basic authentication usually implies the usage of Transport Layer Security.
 
 ### systemd integration
 

--- a/doc/sap_host_exporter.yaml
+++ b/doc/sap_host_exporter.yaml
@@ -18,9 +18,19 @@ log-level: "info"
 # The default value will try to connect locally to instance number 00, without TLS.
 sap-control-url: "localhost:50013"
 
-# Authentication credentials for the SAPControl web service, e.g. <sid>adm user and password.
+# HTTP Basic Authentication credentials for the SAPControl web service, e.g. <sid>adm user and password.
 #
 # These are empty by default, which will cause the exporter to gracefully fail at collecting most metrics.
 # Make sure this file's permissions are set to 600.
+#
+# It is strongly suggested to use the TLS endpoint when using this authentication scheme.
 sap-control-user: ""
 sap-control-password: ""
+
+# The path to a Unix Domain Socket to access SAPControl locally.
+#
+# This is usually /tmp/.sapstream5<instance number>13
+#
+# If this is specified, sap-control-url setting will be ignored.
+# UDS connection doesn't require authentication
+sap-control-uds: ""

--- a/internal/sapcontrol/client.go
+++ b/internal/sapcontrol/client.go
@@ -1,0 +1,35 @@
+package sapcontrol
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/hooklift/gowsdl/soap"
+	"github.com/spf13/viper"
+)
+
+func NewSoapClient(config *viper.Viper) *soap.Client {
+	socket := config.GetString("sap-control-uds")
+
+	if socket != "" {
+		udsClient := &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					d := net.Dialer{}
+					return d.DialContext(ctx, "unix", socket)
+				},
+			},
+		}
+		return soap.NewClient("", soap.WithHTTPClient(udsClient))
+	}
+
+	client := soap.NewClient(
+		config.GetString("sap-control-url"),
+		soap.WithBasicAuth(
+			config.GetString("sap-control-user"),
+			config.GetString("sap-control-password"),
+		),
+	)
+	return client
+}

--- a/internal/sapcontrol/client.go
+++ b/internal/sapcontrol/client.go
@@ -21,6 +21,8 @@ func NewSoapClient(config *viper.Viper) *soap.Client {
 				},
 			},
 		}
+		// The url used here is just phony:
+		// we need a well formed url to create the instance but the above DialContext function won't actually use it.
 		return soap.NewClient("http://unix", soap.WithHTTPClient(udsClient))
 	}
 

--- a/internal/sapcontrol/client.go
+++ b/internal/sapcontrol/client.go
@@ -21,7 +21,7 @@ func NewSoapClient(config *viper.Viper) *soap.Client {
 				},
 			},
 		}
-		return soap.NewClient("", soap.WithHTTPClient(udsClient))
+		return soap.NewClient("http://unix", soap.WithHTTPClient(udsClient))
 	}
 
 	client := soap.NewClient(

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hooklift/gowsdl/soap"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -24,6 +23,7 @@ func init() {
 	flag.String("address", "0.0.0.0", "The address to listen on for HTTP requests")
 	flag.String("log-level", "info", "The minimum logging level; levels are, in ascending order: debug, info, warn, error")
 	flag.String("sap-control-url", "localhost:50013", "The URL of the SAPControl SOAP web service, e.g. $HOST:$PORT")
+	flag.String("sap-control-uds", "", "The path to the SAPControl Unix Domain Socket. If set, this will be used instead of the URL.")
 	flag.StringP("config", "c", "", "The path to a custom configuration file. NOTE: it must be in yaml format.")
 }
 
@@ -37,13 +37,7 @@ func main() {
 		log.Fatalf("Could not initialize config: %s", err)
 	}
 
-	client := soap.NewClient(
-		config.GetString("sap-control-url"),
-		soap.WithBasicAuth(
-			config.GetString("sap-control-user"),
-			config.GetString("sap-control-password"),
-		),
-	)
+	client := sapcontrol.NewSoapClient(config)
 	webService := sapcontrol.NewWebService(client)
 
 	startServiceCollector, err := start_service.NewCollector(webService)


### PR DESCRIPTION
This PR adds the funcitonality to use local Unix Domain Sockets to access SAPControl instead of TCP/IP.
If a `sap-control-uds` setting is specified, then it will take precedence over `sap-control-url`.
SAPControl doesn't require authentication when connecting via UDS.