### PR TITLE
make error handling inside Collect cycles more consistent

### DIFF
--- a/collector/alert/alert.go
+++ b/collector/alert/alert.go
@@ -10,9 +10,9 @@ import (
 	"github.com/SUSE/sap_host_exporter/internal/sapcontrol"
 )
 
-func NewCollector(webService sapcontrol.WebService) (*dispatcherCollector, error) {
+func NewCollector(webService sapcontrol.WebService) (*alertCollector, error) {
 
-	c := &dispatcherCollector{
+	c := &alertCollector{
 		collector.NewDefaultCollector("alert"),
 		webService,
 	}
@@ -23,12 +23,12 @@ func NewCollector(webService sapcontrol.WebService) (*dispatcherCollector, error
 	return c, nil
 }
 
-type dispatcherCollector struct {
+type alertCollector struct {
 	collector.DefaultCollector
 	webService sapcontrol.WebService
 }
 
-func (c *dispatcherCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *alertCollector) Collect(ch chan<- prometheus.Metric) {
 	log.Debugln("Collecting Alert metrics")
 
 	var err error
@@ -40,13 +40,12 @@ func (c *dispatcherCollector) Collect(ch chan<- prometheus.Metric) {
 	}, ch)
 
 	if err != nil {
-		log.Warnf("Some metrics could not be recorded: %s", err)
+		log.Warnf("Alert Collector scrape failed: %s", err)
 	}
 }
 
-func (c *dispatcherCollector) recordHAConfigChecks(ch chan<- prometheus.Metric) error {
+func (c *alertCollector) recordHAConfigChecks(ch chan<- prometheus.Metric) error {
 	response, err := c.webService.HACheckConfig()
-
 	if err != nil {
 		return errors.Wrap(err, "SAPControl web service error")
 	}
@@ -59,7 +58,7 @@ func (c *dispatcherCollector) recordHAConfigChecks(ch chan<- prometheus.Metric) 
 	return nil
 }
 
-func (c *dispatcherCollector) recordHAFailoverConfigChecks(ch chan<- prometheus.Metric) error {
+func (c *alertCollector) recordHAFailoverConfigChecks(ch chan<- prometheus.Metric) error {
 	response, err := c.webService.HACheckFailoverConfig()
 
 	if err != nil {
@@ -74,7 +73,7 @@ func (c *dispatcherCollector) recordHAFailoverConfigChecks(ch chan<- prometheus.
 	return nil
 }
 
-func (c *dispatcherCollector) recordHAChecks(checks []*sapcontrol.HACheck, ch chan<- prometheus.Metric) error {
+func (c *alertCollector) recordHAChecks(checks []*sapcontrol.HACheck, ch chan<- prometheus.Metric) error {
 	for _, check := range checks {
 		err := c.recordHACheck(check, ch)
 		if err != nil {
@@ -84,7 +83,7 @@ func (c *dispatcherCollector) recordHAChecks(checks []*sapcontrol.HACheck, ch ch
 	return nil
 }
 
-func (c *dispatcherCollector) recordHACheck(check *sapcontrol.HACheck, ch chan<- prometheus.Metric) error {
+func (c *alertCollector) recordHACheck(check *sapcontrol.HACheck, ch chan<- prometheus.Metric) error {
 	stateCode, err := sapcontrol.HaVerificationStateToFloat(check.State)
 	category, err := sapcontrol.HaCheckCategoryToString(check.Category)
 	if err != nil {
@@ -95,7 +94,7 @@ func (c *dispatcherCollector) recordHACheck(check *sapcontrol.HACheck, ch chan<-
 	return nil
 }
 
-func (c *dispatcherCollector) recordHAFailoverActive(ch chan<- prometheus.Metric) error {
+func (c *alertCollector) recordHAFailoverActive(ch chan<- prometheus.Metric) error {
 	response, err := c.webService.HAGetFailoverConfig()
 
 	if err != nil {

--- a/collector/alert/alert.go
+++ b/collector/alert/alert.go
@@ -67,7 +67,7 @@ func (c *alertCollector) recordHAFailoverConfigChecks(ch chan<- prometheus.Metri
 
 	err = c.recordHAChecks(response.Checks, ch)
 	if err != nil {
-		return errors.Wrap(err, "Could not record HACheck")
+		return errors.Wrap(err, "could not record HACheck")
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func (c *alertCollector) recordHACheck(check *sapcontrol.HACheck, ch chan<- prom
 	stateCode, err := sapcontrol.HaVerificationStateToFloat(check.State)
 	category, err := sapcontrol.HaCheckCategoryToString(check.Category)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to process SAPControl HACheck data: %v", *check)
+		return errors.Wrapf(err, "unable to process SAPControl HACheck data: %v", *check)
 	}
 	ch <- c.MakeGaugeMetric("ha_check", stateCode, check.Description, category, check.Comment)
 

--- a/collector/start_service/start_service.go
+++ b/collector/start_service/start_service.go
@@ -49,7 +49,7 @@ func (c *startServiceCollector) recordProcesses(ch chan<- prometheus.Metric) err
 	for _, process := range processList.Processes {
 		state, err := sapcontrol.StateColorToFloat(process.Dispstatus)
 		if err != nil {
-			return errors.Wrapf(err, "Unable to process SAPControl OSProcess data: %v", *process)
+			return errors.Wrapf(err, "unable to process SAPControl OSProcess data: %v", *process)
 		}
 		ch <- c.MakeGaugeMetric("processes", state, process.Name, strconv.Itoa(int(process.Pid)), process.Textstatus)
 	}

--- a/collector/start_service/start_service.go
+++ b/collector/start_service/start_service.go
@@ -34,7 +34,7 @@ func (c *startServiceCollector) Collect(ch chan<- prometheus.Metric) {
 
 	err := c.recordProcesses(ch)
 	if err != nil {
-		log.Warnf("Some metrics could not be recorded: %s", err)
+		log.Warnf("Start Service Collector scrape failed: %s", err)
 		return
 	}
 }


### PR DESCRIPTION
This PR makes warn-level error reporting inside `Collect` cycles more consistent by wrapping and returning errors where possible instead of logging them directly inside nested methods.

The log lines now all follow the same convention of reporting which collector triggered the warning.