### PR TITLE
Check if the process contains instead of matches

### DIFF
--- a/collector/registry/optional_collectors.go
+++ b/collector/registry/optional_collectors.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"strings"
+
 	"github.com/SUSE/sap_host_exporter/collector/dispatcher"
 	"github.com/SUSE/sap_host_exporter/collector/enqueue_server"
 	"github.com/SUSE/sap_host_exporter/lib/sapcontrol"
@@ -19,10 +21,10 @@ func RegisterOptionalCollectors(webService sapcontrol.WebService) error {
 	}
 
 	for _, process := range processList.Processes {
-		if process.Name == "msg_server" {
+		if strings.Contains(process.Name, "msg_server") {
 			enqueueFound = true
 		}
-		if process.Name == "disp+work" {
+		if strings.Contains(process.Name, "disp+work") {
 			dispatcherFound = true
 		}
 		if enqueueFound == true && dispatcherFound == true {

--- a/collector/registry/optional_collectors_test.go
+++ b/collector/registry/optional_collectors_test.go
@@ -47,6 +47,16 @@ func TestActivationDispatcherOutput(t *testing.T) {
 				Elapsedtime: "",
 				Pid:         30786,
 			},
+			{
+				// activate the collector (on windows)
+				Name:        "disp+work.EXE",
+				Description: "foobar2",
+				Dispstatus:  sapcontrol.STATECOLOR_YELLOW,
+				Textstatus:  "Stopping",
+				Starttime:   "",
+				Elapsedtime: "",
+				Pid:         30785,
+			},
 		},
 	}, nil)
 
@@ -81,6 +91,16 @@ func TestActivationEnqueueServerOutput(t *testing.T) {
 				Starttime:   "",
 				Elapsedtime: "",
 				Pid:         30786,
+			},
+			{
+				// activate the collector (On Windows)
+				Name:        "msg_server.EXE",
+				Description: "foobar2",
+				Dispstatus:  sapcontrol.STATECOLOR_YELLOW,
+				Textstatus:  "Stopping",
+				Starttime:   "",
+				Elapsedtime: "",
+				Pid:         30785,
 			},
 		},
 	}, nil)


### PR DESCRIPTION
Check if the process name contains value instead of matching the value.
This makes it possible to run the exporter on windows.