### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/lib/sapcontrol/current_instance.go
+++ b/lib/sapcontrol/current_instance.go
@@ -3,6 +3,7 @@ package sapcontrol
 import (
 	"fmt"
 	"strconv"
+	"math"
 
 	"github.com/pkg/errors"
 )
@@ -37,10 +38,14 @@ func (s *webService) GetCurrentInstance() (*CurrentSapInstance, error) {
 		for _, prop := range response.Properties {
 			switch prop.Property {
 			case "SAPSYSTEM":
-				var num int
-				num, err = strconv.Atoi(prop.Value)
+				var num int64
+				num, err = strconv.ParseInt(prop.Value, 10, 32)
 				if err != nil {
-					err = errors.Wrap(err, "could not parse instance number to int")
+					err = errors.Wrap(err, "could not parse instance number to int32")
+					return
+				}
+				if num < math.MinInt32 || num > math.MaxInt32 {
+					err = errors.New("parsed instance number out of int32 range")
 					return
 				}
 				s.currentSapInstance.Number = int32(num)

--- a/lib/sapcontrol/current_instance.go
+++ b/lib/sapcontrol/current_instance.go
@@ -2,8 +2,8 @@ package sapcontrol
 
 import (
 	"fmt"
-	"strconv"
 	"math"
+	"strconv"
 
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Fixes [https://github.com/SUSE/sap_host_exporter/security/code-scanning/1](https://github.com/SUSE/sap_host_exporter/security/code-scanning/1)

To fix the problem, we should avoid using `strconv.Atoi` and instead use `strconv.ParseInt` with a specified bit size of 32. This ensures that the parsed value is within the range of `int32`. Additionally, we should add bounds checking to ensure the parsed value does not exceed the limits of `int32`.

1. Replace the use of `strconv.Atoi` with `strconv.ParseInt` specifying a bit size of 32.
2. Add bounds checking to ensure the parsed value is within the range of `int32`.
3. Update the conversion to `int32` only after confirming the value is within bounds.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
